### PR TITLE
Fix comment length limits in ViewPaste

### DIFF
--- a/frontend/pastebin_frontend/src/components/ViewPaste.jsx
+++ b/frontend/pastebin_frontend/src/components/ViewPaste.jsx
@@ -96,16 +96,16 @@ const ViewPaste = () => {
                             <h3>Add a Comment</h3>
                             <input
                                 type="text"
-                                placeholder="Your name (max 25 chars)"
+                                placeholder="Your name (max 15 chars)"
                                 value={username}
                                 onChange={(e) => setUsername(e.target.value)}
-                                maxLength="25" // Restricts the input length to 15 characters
+                                maxLength="15" // Restricts the input length to 15 characters
                             />
                             <textarea
-                                placeholder="Your comment (max 200 chars)"
+                                placeholder="Your comment (max 100 chars)"
                                 value={newComment}
                                 onChange={(e) => setNewComment(e.target.value)}
-                                maxLength="200" // Restricts the input length to 100 characters
+                                maxLength="100" // Restricts the input length to 100 characters
                             ></textarea>
                             <button onClick={handleCommentSubmit}>Submit</button>
                         </div>


### PR DESCRIPTION
## Summary
- align the username and comment length limits in the comment form with validation logic

## Testing
- `mvn test` *(fails: command not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863b918a66c83228742a9da5e53b6d8